### PR TITLE
Check simple class name for unmarshaller

### DIFF
--- a/reader/src/main/java/jp/yokomark/remoteview/reader/ActionMap.java
+++ b/reader/src/main/java/jp/yokomark/remoteview/reader/ActionMap.java
@@ -25,35 +25,37 @@ import jp.yokomark.remoteview.reader.unmarshaller.ViewPaddingActionUnmarshaller;
  * @author KeishinYokomaku
  */
 public enum ActionMap {
-    SET_PENDING_INTENT(1, new SetOnClickPendingIntentActionUnmarshaller()),
-    REFLECTION(2, new ReflectionActionUnmarshaller()),
-    SET_DRAWABLE_PARAMS(3, new SetDrawableParamsActionUnmarshaller()),
-    VIEW_GROUP(4, new ViewGroupActionUnmarshaller()),
-    REFLECTION_WITHOUT_PARAMS(5, new ReflectionWithoutParamsActionUnmarshaller()),
-    SET_EMPTY_VIEW(6, new SetEmptyViewActionUnmarshaller()),
-    SET_PENDING_INTENT_TEMPLATE(8, new SetPendingIntentTemplateActionUnmarshaller()),
-    SET_FILL_IN_INTENT(9, new SetOnClickFillInIntentActionUnmarshaller()),
-    SET_REMOTE_VIEWS_ADAPTER_INTENT(10, new SetRemoteViewsAdapterIntentActionUnmarshaller()),
-    TEXT_VIEW_DRAWABLE(11, new TextViewDrawableActionUnmarshaller()),
-    BITMAP_REFLECTION(12, new BitmapReflectionActionUnmarshaller()),
-    TEXT_VIEW_SIZE(13, new TextViewSizeActionUnmarshaller()),
-    VIEW_PADDING(14, new ViewPaddingActionUnmarshaller()),
-    SET_REMOTE_VIEWS_ADAPTER_LIST(15, new SetRemoteViewsAdapterListActionUnmarshaller()),
-    TEXT_VIEW_DRAWABLE_COLOR_FILTER_ACTION(17, new TextViewDrawableColorFilterActionUnmarshaller()),
-    SET_LAUNCH_PENDING_INTENT(20, new SetLaunchPendingIntentActionUnmarshaller()), // why do you do that to us ms samsung?
-    UNKNOWN(0, new UnknownActionUnmarshaller());
+    SET_PENDING_INTENT("SetOnClickPendingIntent", 1, new SetOnClickPendingIntentActionUnmarshaller()),
+    REFLECTION("ReflectionAction", 2, new ReflectionActionUnmarshaller()),
+    SET_DRAWABLE_PARAMS("SetDrawableParamsAction", 3, new SetDrawableParamsActionUnmarshaller()),
+    VIEW_GROUP("ViewGroupAction", 4, new ViewGroupActionUnmarshaller()),
+    REFLECTION_WITHOUT_PARAMS("ReflectionWithoutParamsAction", 5, new ReflectionWithoutParamsActionUnmarshaller()),
+    SET_EMPTY_VIEW("SetEmptyViewAction", 6, new SetEmptyViewActionUnmarshaller()),
+    SET_PENDING_INTENT_TEMPLATE("SetPendingIntentTemplateAction", 8, new SetPendingIntentTemplateActionUnmarshaller()),
+    SET_FILL_IN_INTENT("SetOnClickFillInIntent", 9, new SetOnClickFillInIntentActionUnmarshaller()),
+    SET_REMOTE_VIEWS_ADAPTER_INTENT("SetRemoteViewsAdapterIntent", 10, new SetRemoteViewsAdapterIntentActionUnmarshaller()),
+    TEXT_VIEW_DRAWABLE("TextViewDrawableAction", 11, new TextViewDrawableActionUnmarshaller()),
+    BITMAP_REFLECTION("BitmapReflectionAction", 12, new BitmapReflectionActionUnmarshaller()),
+    TEXT_VIEW_SIZE("TextViewSizeAction", 13, new TextViewSizeActionUnmarshaller()),
+    VIEW_PADDING("ViewPaddingAction", 14, new ViewPaddingActionUnmarshaller()),
+    SET_REMOTE_VIEWS_ADAPTER_LIST("SetRemoteViewsAdapterList", 15, new SetRemoteViewsAdapterListActionUnmarshaller()),
+    TEXT_VIEW_DRAWABLE_COLOR_FILTER_ACTION("TextViewDrawableColorFilterAction", 17, new TextViewDrawableColorFilterActionUnmarshaller()),
+    SET_LAUNCH_PENDING_INTENT("SetLaunchPendingIntent", 20, new SetLaunchPendingIntentActionUnmarshaller()), // why do you do that to us ms samsung?
+    UNKNOWN("", 0, new UnknownActionUnmarshaller());
 
+    private final String simpleClassName;
     private final int tag;
     private final Unmarshaller unmarshaller;
 
-    ActionMap(int tag, @NonNull Unmarshaller unmarshaller) {
+    ActionMap(String simpleClassName, int tag, @NonNull Unmarshaller unmarshaller) {
+        this.simpleClassName = simpleClassName;
         this.tag = tag;
         this.unmarshaller = unmarshaller;
     }
 
-    public static ActionMap find(int tag) {
+    public static ActionMap find(int tag, String simpleClassName) {
         for (ActionMap actionMap : values()) {
-            if (actionMap.tag == tag) {
+            if (actionMap.tag == tag || actionMap.simpleClassName.equals(simpleClassName)) {
                 return actionMap;
             }
         }

--- a/reader/src/main/java/jp/yokomark/remoteview/reader/RemoteViewsReader.java
+++ b/reader/src/main/java/jp/yokomark/remoteview/reader/RemoteViewsReader.java
@@ -41,7 +41,8 @@ public class RemoteViewsReader {
                 p.writeToParcel(action, 0);
                 action.setDataPosition(0);
 
-                ActionMap mapped = ActionMap.find(action.readInt());
+
+                ActionMap mapped = ActionMap.find(action.readInt(), p.getClass().getSimpleName());
                 actions.add(mapped.getUnmarshaller().unmarshal(p, action));
             }
             return new RemoteViewsInfo(applicationInfo, layoutId, actions);


### PR DESCRIPTION
From Android P, RemoteViewsAction.readInt() returns always 0 so Unmarshaller is always UNKNOWN type.
I added to check simple class name to get Unmarshaller.
Verified working on Android 8 and 9.